### PR TITLE
server: Añadir logger de HTTPS con Morgan

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -26,7 +26,9 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.0",
+    "morgan": "^1.10.1",
     "mysql2": "^3.6.5",
+    "winston": "^3.19.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {
@@ -35,6 +37,7 @@
     "@types/express": "^4.17.21",
     "@types/jest": "^29.5.11",
     "@types/jsonwebtoken": "^9.0.7",
+    "@types/morgan": "^1.9.10",
     "@types/node": "^20.10.6",
     "@typescript-eslint/eslint-plugin": "^6.17.0",
     "@typescript-eslint/parser": "^6.17.0",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -6,6 +6,7 @@ import { errorHandler } from './middleware/errorHandler';
 import authRoutes from './routes/auth';
 import roomRoutes from './routes/rooms';
 import reservasRoutes from './routes/reservas';
+import morganMiddleware from './middleware/morgan';
 
 const app: Express = express();
 
@@ -13,6 +14,7 @@ const app: Express = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(cors());
+app.use(morganMiddleware);
 
 // Health check endpoint
 app.get('/health', (_req, res) => {

--- a/server/src/middleware/errorHandler.ts
+++ b/server/src/middleware/errorHandler.ts
@@ -7,8 +7,6 @@ export const errorHandler = (
   res: Response,
   _next: NextFunction
 ): void => {
-  console.error('Error:', err);
-
   if (err instanceof ApiError) {
     res.status(err.statusCode).json({
       success: false,

--- a/server/src/middleware/morgan.ts
+++ b/server/src/middleware/morgan.ts
@@ -1,0 +1,26 @@
+import winston from 'winston';
+import morgan from 'morgan';
+
+const { combine, timestamp, json } = winston.format;
+
+const logger = winston.createLogger({
+  level: 'http',
+  format: combine(
+    timestamp({
+      format: 'YYYY-MM-DD hh:mm:ss.SSS A',
+    }),
+    json(),
+  ),
+  transports: [new winston.transports.Console(), new winston.transports.File({filename: 'combined.log'})],
+});
+
+const morganMiddleware = morgan(
+  ':method :url :status :res[content-length] - :response-time ms',
+  {
+    stream: {
+      write: (message) => logger.http(message.trim()),
+    },
+  },
+);
+
+export default morganMiddleware;


### PR DESCRIPTION
Añade un logger con Morgan para tener registro de las solicitudes hechas al servidor.

Relacionado a #3 